### PR TITLE
Add 'reencode' yaml option to disable reencoding a segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ This is a full example that demonstrates all features.
 # A basic example
 # Output is relative to the output-dir command line argument.
 - output: day1-welcome.mp4
+  # If given, do not reencode this segment even if --reencode is given
+  # (useful for segments that start at 00:00).  'reencode: true' does
+  # nothing, this is the default and --reencode must still be
+  # specified on the command line.
+  #reencode: false
   time:
     - start: 12:20
     - end: 31:14

--- a/ffmpeg-editlist.py
+++ b/ffmpeg-editlist.py
@@ -187,6 +187,7 @@ if __name__ == '__main__':
                 workshop_title = segment['workshop_title']
             if 'output' not in segment:
                 continue
+            allow_reencode = segment.get('reencode', True)
             # Exclude non-matching files if '--limit' specified.
             if args.limit and not any(limit_match in segment['output'] for limit_match in args.limit):
                 continue
@@ -259,7 +260,7 @@ if __name__ == '__main__':
                 tmp_outputs.append(tmp_out)
                 cmd = ['ffmpeg', '-loglevel', str(LOGLEVEL),
                        '-i', input1, '-ss', start, '-to', stop,
-                       *(FFMPEG_ENCODE if args.reencode or filters else FFMPEG_COPY),
+                       *(FFMPEG_ENCODE if (args.reencode and allow_reencode) or filters else FFMPEG_COPY),
                        *filters,
                        tmp_out,
                        ]


### PR DESCRIPTION
- If a segment starts at 00:00, it doesn't need reencoding (ever?).
- This allows one to specify 'reencode: false' in the yaml to disable
  this.  The default is true, setting it to true does nothing (you
  still must use --reencode on the command line).
- Review: general check
